### PR TITLE
Update tests with default workers per core set to 1

### DIFF
--- a/tests/test_01_main/test_defaults.py
+++ b/tests/test_01_main/test_defaults.py
@@ -15,7 +15,7 @@ def verify_container(container, response_text):
     assert config_data["host"] == "0.0.0.0"
     assert config_data["port"] == "80"
     assert config_data["loglevel"] == "info"
-    assert config_data["workers"] > 2
+    assert config_data["workers"] >= 2
     assert config_data["bind"] == "0.0.0.0:80"
     logs = get_logs(container)
     assert "Checking for script in /app/prestart.sh" in logs

--- a/tests/test_01_main/test_defaults.py
+++ b/tests/test_01_main/test_defaults.py
@@ -11,7 +11,7 @@ client = docker.from_env()
 
 def verify_container(container, response_text):
     config_data = get_config(container)
-    assert config_data["workers_per_core"] == 2
+    assert config_data["workers_per_core"] == 1
     assert config_data["host"] == "0.0.0.0"
     assert config_data["port"] == "80"
     assert config_data["loglevel"] == "info"


### PR DESCRIPTION
:white_check_mark: Update tests with default workers per core set to 1.

Depends on https://github.com/tiangolo/uvicorn-gunicorn-docker/pull/5