### PR TITLE
:heavy_plus_sign: Add Python 3.8 with Alpine 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: xenial
+dist: bionic
 
 language: python
 
 python:
-  - "3.7"
+  - "3.8"
 
 install:
   - pip install docker pytest
@@ -13,8 +13,10 @@ services:
 
 env:
   - NAME='latest' BUILD_PATH='python3.7' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7'
+  - NAME='python3.8' BUILD_PATH='python3.8' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.8'
   - NAME='python3.7' BUILD_PATH='python3.7' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6' BUILD_PATH='python3.6' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.6'
+  - NAME='python3.8-alpine3.10' BUILD_PATH='python3.8-alpine3.10' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.8'
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.7'
   - NAME='python3.6-alpine3.8' BUILD_PATH='python3.6-alpine3.8' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.6'
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 ## Supported tags and respective `Dockerfile` links
 
+* [`python3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.8/Dockerfile)
 * [`python3.7`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.7/Dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.6/Dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.6-alpine3.8/Dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.7-alpine3.8/Dockerfile)
+* [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.8-alpine3.10/Dockerfile)
 
 **Note**: Note: There are [tags for each build date](https://hub.docker.com/r/tiangolo/uvicorn-gunicorn-fastapi/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/uvicorn-gunicorn-fastapi:python3.7-2019-10-15`.
 
 # uvicorn-gunicorn-fastapi
 
-[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance [**FastAPI**](https://fastapi.tiangolo.com/) web applications in **[Python](https://www.python.org/) 3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
+[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance [**FastAPI**](https://fastapi.tiangolo.com/) web applications in **[Python](https://www.python.org/) 3.8**, **3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
 
 **GitHub repo**: [https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker)
 

--- a/python3.8-alpine3.10/Dockerfile
+++ b/python3.8-alpine3.10/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install fastapi
+
+COPY ./app /app

--- a/python3.8-alpine3.10/app/main.py
+++ b/python3.8-alpine3.10/app/main.py
@@ -1,0 +1,13 @@
+import sys
+
+from fastapi import FastAPI
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    message = f"Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python {version}"
+    return {"message": message}

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install fastapi
+
+COPY ./app /app

--- a/python3.8/app/main.py
+++ b/python3.8/app/main.py
@@ -1,0 +1,13 @@
+import sys
+
+from fastapi import FastAPI
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    message = f"Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python {version}"
+    return {"message": message}

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -9,6 +9,11 @@ environments = [
         "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7",
     },
     {
+        "NAME": "python3.8",
+        "BUILD_PATH": "python3.8",
+        "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.8",
+    },
+    {
         "NAME": "python3.7",
         "BUILD_PATH": "python3.7",
         "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7",
@@ -17,6 +22,11 @@ environments = [
         "NAME": "python3.6",
         "BUILD_PATH": "python3.6",
         "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.6",
+    },
+    {
+        "NAME": "python3.8-alpine3.10",
+        "BUILD_PATH": "python3.8-alpine3.10",
+        "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.8",
     },
     {
         "NAME": "python3.7-alpine3.8",


### PR DESCRIPTION
Hello there!

I would like to use an official Python 3.8 Docker image for `fastapi` if possible.

Based on previous files and tracked all references of both 3.6 and 3.7 in existing files to include Python 3.8 related files and modifications.

Given that Python 3.8 is still very recent, this pull request does not modify `latest` tag yet nor changes previous Dockerfile's Alpine versions either. Only Python 3.8 uses Alpine 3.10, as there was no other Alpine version to use from Python official images.

For testing purposes, I set forked repository in my Travis CI account, but there is a deadlock in testing from Docker Hub, given that 3.8 was not registered at @tiangolo's Docker Hub account yet.