### PR TITLE
Add python3.7-slim image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - NAME='latest' BUILD_PATH='python3.7' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.7' BUILD_PATH='python3.7' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6' BUILD_PATH='python3.6' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.6'
+  - NAME='python3.7-slim' BUILD_PATH='python3.7-slim' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7-slim'
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.7'
   - NAME='python3.6-alpine3.8' BUILD_PATH='python3.6-alpine3.8' TEST_STR1='Hello world! From FastAPI running on Uvicorn with Gunicorn in Alpine. Using Python 3.6'
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * [`python3.7`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.7/Dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.6/Dockerfile)
+* [`python3.7-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.7-slim/Dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.6-alpine3.8/Dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/python3.7-alpine3.8/Dockerfile)
 

--- a/python3.7-slim/Dockerfile
+++ b/python3.7-slim/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn:python3.7-slim
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install fastapi
+
+COPY ./app /app

--- a/python3.7-slim/app/main.py
+++ b/python3.7-slim/app/main.py
@@ -1,0 +1,13 @@
+import sys
+
+from fastapi import FastAPI
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    message = f"Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python {version}"
+    return {"message": message}

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -14,6 +14,11 @@ environments = [
         "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7",
     },
     {
+        "NAME": "python3.7-slim",
+        "BUILD_PATH": "python3.7-slim",
+        "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.7-slim",
+    },
+    {
         "NAME": "python3.6",
         "BUILD_PATH": "python3.6",
         "TEST_STR1": "Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python 3.6",


### PR DESCRIPTION
This PR adds a smaller image based on `tiangolo/uvicorn-gunicorn:python3.7-slim` itself based on `python:3.7-slim`.
The resulting image with `fastapi` is 376MB instead of 983MB.
This PR fixes #15 