### PR TITLE
✏ Fix percentage typo on README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ FastAPI is a modern, fast (high-performance), web framework for building APIs wi
 The key features are:
 
 * **Fast**: Very high performance, on par with **NodeJS** and **Go** (thanks to Starlette and Pydantic).
-* **Fast to code**: Increase the speed to develop features by about 300% to 500% *.
+* **Fast to code**: Increase the speed to develop features by about 200% to 300% *.
 * **Less bugs**: Reduce about 40% of human (developer) induced errors. *
 * **Intuitive**: Great editor support. <abbr title="also known as auto-complete, autocompletion, IntelliSense">Completion</abbr> everywhere. Less time debugging.
 * **Easy**: Designed to be easy to use and learn. Less time reading docs.


### PR DESCRIPTION
There's a percentage incompatibility between this project and the https://github.com/tiangolo/fastapi.

I've fixed and assumed the other is the true value. It's not important, but it's good to have them on the same page :)