### PR TITLE
Add images for python 3.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.9"
+            python_version: "3.10"
+          - name: python3.10
+            python_version: "3.10"
           - name: python3.9
             python_version: "3.9"
           - name: python3.8
@@ -21,10 +23,14 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
+          - name: python3.10-slim
+            python_version: "3.10"
           - name: python3.9-slim
             python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"
+          - name: python3.10-alpine3.15
+            python_version: "3.10"
           - name: python3.9-alpine3.14
             python_version: "3.9"
           - name: python3.8-alpine3.10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,9 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.9"
+            python_version: "3.10"
+          - name: python3.10
+            python_version: "3.10"
           - name: python3.9
             python_version: "3.9"
           - name: python3.8
@@ -21,10 +23,14 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
+          - name: python3.10-slim
+            python_version: "3.10"
           - name: python3.9-slim
             python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"
+          - name: python3.10-alpine3.15
+            python_version: "3.10"
           - name: python3.9-alpine3.14
             python_version: "3.9"
           - name: python3.8-alpine3.10

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`python3.9`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.9.dockerfile)
+* [`python3.10`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.10.dockerfile)
+* [`python3.9`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.9.dockerfile)
 * [`python3.8`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.8.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.6.dockerfile)
+* [`python3.10-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.10-slim.dockerfile)
 * [`python3.9-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.9-slim.dockerfile)
 * [`python3.8-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.8-slim.dockerfile)
 
 ## Discouraged tags
 
+* [`python3.10-alpine3.15` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.10-alpine3.15.dockerfile)
 * [`python3.9-alpine3.14` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.9-alpine3.14.dockerfile)
 * [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.8-alpine3.10.dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/blob/master/docker-images/python3.7-alpine3.8.dockerfile)
@@ -51,7 +54,7 @@ In those cases (e.g. using Kubernetes) you would probably want to build a **Dock
 For example, your `Dockerfile` could look like:
 
 ```Dockerfile
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /code
 
@@ -158,7 +161,7 @@ You can use this image as a base image for other images.
 Assuming you have a file `requirements.txt`, you could have a `Dockerfile` like this:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
 
 COPY ./requirements.txt /app/requirements.txt
 
@@ -187,7 +190,7 @@ docker build -t myimage ./
 * Create a `Dockerfile` with:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
 
 COPY ./requirements.txt /app/requirements.txt
 
@@ -284,7 +287,7 @@ Let's say you have a project managed with [Poetry](https://python-poetry.org/), 
 Then you could have a `Dockerfile` using Docker multi-stage building with:
 
 ```Dockerfile
-FROM python:3.9 as requirements-stage
+FROM python:3.10 as requirements-stage
 
 WORKDIR /tmp
 
@@ -294,7 +297,7 @@ COPY ./pyproject.toml ./poetry.lock* /tmp/
 
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10
 
 COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
 

--- a/docker-images/python3.10-alpine3.15.dockerfile
+++ b/docker-images/python3.10-alpine3.15.dockerfile
@@ -1,0 +1,8 @@
+FROM tiangolo/uvicorn-gunicorn:python3.10-alpine3.15
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./app /app

--- a/docker-images/python3.10-slim.dockerfile
+++ b/docker-images/python3.10-slim.dockerfile
@@ -1,0 +1,8 @@
+FROM tiangolo/uvicorn-gunicorn:python3.10-slim
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./app /app

--- a/docker-images/python3.10.dockerfile
+++ b/docker-images/python3.10.dockerfile
@@ -1,0 +1,8 @@
+FROM tiangolo/uvicorn-gunicorn:python3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ./app /app

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ use_tag="tiangolo/uvicorn-gunicorn-fastapi:$NAME"
 DOCKERFILE="$NAME"
 
 if [ "$NAME" == "latest" ] ; then
-    DOCKERFILE="python3.9"
+    DOCKERFILE="python3.10"
 fi
 
 docker build -t "$use_tag" --file "./docker-images/${DOCKERFILE}.dockerfile" "./docker-images/"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -3,13 +3,16 @@ import subprocess
 import sys
 
 environments = [
-    {"NAME": "latest", "PYTHON_VERSION": "3.9"},
+    {"NAME": "latest", "PYTHON_VERSION": "3.10"},
+    {"NAME": "python3.10", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
+    {"NAME": "python3.10-slim", "PYTHON_VERSION": "3.10"}
     {"NAME": "python3.9-slim", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-slim", "PYTHON_VERSION": "3.8"},
+    {"NAME": "python3.10-alpine3.15", "PYTHON_VERSION": "3.10"},
     {"NAME": "python3.9-alpine3.14", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-alpine3.10", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7-alpine3.8", "PYTHON_VERSION": "3.7"},


### PR DESCRIPTION
This commit introduces three new images

- python3.10
- python3.10-slim
- python3.10-alpine3.15

It follows the exact same amount of changes as PR #67 did for Python 3.9.

PS: I left the notice / update of README -> "Latest Changes" up to the maintainer ;)

This PR depends on:
https://github.com/tiangolo/uvicorn-gunicorn-docker/pull/99