### PR TITLE
👷 Do not run double CI, run on push only on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
👷 Do not run double CI, run on push only on master