### PR TITLE
Upgrade Gunicorn

### DIFF
--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,3 +1,3 @@
 uvicorn[standard]==0.20.0
-gunicorn==20.1.0
+gunicorn==21.2.0
 fastapi[all]==0.88.0


### PR DESCRIPTION
The Gunicorn version is not fully compatible with Python 3.11.

Source: Gunicorn's changelog:

-  https://docs.gunicorn.org/en/stable/news.html