### PR TITLE
Remove version specification to use the latest packages when building…

### DIFF
--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,3 +1,3 @@
-uvicorn[standard]==0.20.0
-gunicorn==20.1.0
-fastapi[all]==0.88.0
+uvicorn[standard]
+gunicorn
+fastapi[all]

--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,3 +1,7 @@
 uvicorn[standard]
 gunicorn
 fastapi[all]
+requests
+urllib3
+requests
+docker


### PR DESCRIPTION
… docker image.

A breaking change from pydantic this solves is converting models to dict or json. ".json() & .dict()" are now deprecated and use model_dump() and model_dump_json()