### PR TITLE
👷 Simplify pull request workflow triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    types:
-      - opened
-      - synchronize
   workflow_dispatch:
   schedule:
     # cron every week on monday


### PR DESCRIPTION
## Summary
- Simplify workflow `pull_request` event declarations by removing explicit `opened` and `synchronize` activity filters.
- Let GitHub use the default `pull_request` activity set, which also includes `reopened`.

## Validation
- Parsed each changed workflow as YAML before and after the edit.
- Checked the resulting diff is limited to the `pull_request` trigger simplification.

## AI Disclaimer
Using Codex with GPT-5.5. Reviewed manually.
